### PR TITLE
Added nullable primitives, no more setting the prop as null to allow nulls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ var TypeName = stronglyTyped(interface_definition, [prototype], [allowUnspecifie
 ```
 
 `interface_definition` is a plain object of the expected structure with fields containing strings to match `typeof` in the typed objects.
+Additionally those strings can be prefixed with question mark `?` to allow null in addition to expected type.
 
 You can also use `null` or empty `{}` to indicate that the field must exist, without specifying anything else about it.
 
@@ -29,6 +30,7 @@ var Person = stronglyTyped({
         last:"string"
     },
     "age": "number",
+    "phoneNumber": "?string"
     "favorites": []
 })
 
@@ -39,6 +41,7 @@ var joe = Person({
         last:"Average"
     },
     "age": 52,
+    "phoneNumber": null,
     "favorites": ["beer","game"]
 })
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ function validate(obj, desc, parent) {
     Object.keys(desc).forEach(function (key) {
         var descriptionVal = desc[key];
         if (typeof descriptionVal === "string") {
-            if (typeof obj[key] !== descriptionVal) {
+            var isNullable = descriptionVal[0] === "?";
+            var isInvalidForNullable = obj[key] !== null && typeof obj[key] !== descriptionVal.substr(1);
+            var itsJustInvald = typeof obj[key] !== descriptionVal;
+            if (isNullable ? isInvalidForNullable : itsJustInvald) {
                 errors.push(parent + key + ':' + (typeof obj[key]));
             }
         } else {

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,11 @@ var TypeC = stronglyTyped({
     "b": !"falsy indicates a field must exist, any type"
 })
 
+var TypeD = stronglyTyped({
+    "a": "?string",
+    "b": "?number"
+})
+
 var Autoid1 = stronglyTyped({
     "id": "number",
     "text": "string"
@@ -185,5 +190,34 @@ assert.throws(
     /b\.c:string$/,
     "expected TypeError on incorrect object definition3"
 );
+
+assert.doesNotThrow(function () {
+    var x = TypeD({
+        a: "test",
+        b: 44
+    })
+
+    var y = TypeD({
+        a: null,
+        b: 44
+    })
+
+    var z = TypeD({
+        a: "test",
+        b: null
+    })
+
+    var w = TypeD({
+        a: null,
+        b: null
+    })
+}, "expected object creation with primitive nullables to succeed")
+
+assert.throws(function() {
+    var x = TypeD({
+        a: undefined,
+        b: undefined
+    })
+}, "expected object with nullables set to undefined to throw")
 
 console.log('done');


### PR DESCRIPTION
_Why?_
Internally in the project we tend to comment out fields which we want to have the prop nullable and set the factory to allow extra fields. This drops the verification of the fields.

_Why question mark?_
Simulating typescript with their { prop?: type } for nullable props.

_Potential improvements:_
Make arrays and objects nullable as well, but I can't think of any other way than adding new prototype to the chain and checking against it. Downfall of this is extending this small library, since the prototype would need to be exported as well..