### PR TITLE
Added support for array contents validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ var joe = Person({
 Person.created(joe) === true
 ```
 
+If `[]` is left empty in description, inner elements of the array are not validated. If there is first element in the array description, it's treated as schema for each element inside the array. Additional elements in description are omitted.
+
+_Example - array deep validation_
+
+```javascript
+var Person2 = stronglyTyped({
+    "name": "string",
+    "favorites": [
+        {
+            "id": "number",
+            "value": "string"
+        }
+    ]
+})
+
+//create instance
+var moe = Person2({
+    "name": "Moe Average"
+    "favorites": [
+        { "id": 1, "value": "beer" },
+        { "id": 2, "value": "game" }
+    ]
+})
+
+//check type
+Person2.created(moe) === true
+```
+
 More examples in tests/index.js
 
 ## No new keyword

--- a/test/arrayElementsValidation.js
+++ b/test/arrayElementsValidation.js
@@ -1,0 +1,70 @@
+var stronglyTyped = require("../");
+var assert = require("assert");
+
+var BackwardCapability = stronglyTyped({
+    array: []
+});
+
+var SimpleValue = stronglyTyped({
+    array: [
+        "string"
+    ]
+});
+
+var Object = stronglyTyped({
+    array: [
+        {
+            value: "string"
+        }
+    ]
+});
+
+assert.doesNotThrow(function() {
+    BackwardCapability({
+        array: [
+            "a",
+            2,
+            { value: "c" }
+        ]
+    })
+});
+
+assert.doesNotThrow(function() {
+    SimpleValue({
+        array: [
+            "a",
+            "b",
+            "c"
+        ]
+    })
+});
+
+assert.throws(function() {
+    SimpleValue({
+        array: [
+            "a",
+            2,
+            "c"
+        ]
+    })
+});
+
+assert.doesNotThrow(function() {
+    Object({
+        array: [
+            { value: "a" },
+            { value: "b" },
+            { value: "c" }
+        ]
+    })
+});
+
+assert.throws(function() {
+    Object({
+        array: [
+            { value: "a" },
+            { value: 2 },
+            { value: "c" }
+        ]
+    })
+});

--- a/test/arrayElementsValidation.js
+++ b/test/arrayElementsValidation.js
@@ -11,10 +11,22 @@ var SimpleValue = stronglyTyped({
     ]
 });
 
-var Object = stronglyTyped({
+var ObjectValue = stronglyTyped({
     array: [
         {
             value: "string"
+        }
+    ]
+});
+
+var FreakyValue = stronglyTyped({
+    outerArray: [
+        {
+            innerArray: [
+                {
+                    value: "string"
+                }
+            ]
         }
     ]
 });
@@ -50,7 +62,7 @@ assert.throws(function() {
 });
 
 assert.doesNotThrow(function() {
-    Object({
+    ObjectValue({
         array: [
             { value: "a" },
             { value: "b" },
@@ -60,11 +72,65 @@ assert.doesNotThrow(function() {
 });
 
 assert.throws(function() {
-    Object({
+    ObjectValue({
         array: [
             { value: "a" },
             { value: 2 },
             { value: "c" }
+        ]
+    })
+});
+
+assert.doesNotThrow(function () {
+    FreakyValue({
+        outerArray: [
+            {
+                innerArray: [
+                    {
+                        value: "a"
+                    },
+                    {
+                        value: "b"
+                    }
+                ]
+            },
+            {
+                innerArray: [
+                    {
+                        value: "c"
+                    },
+                    {
+                        value: "d"
+                    }
+                ]
+            }
+        ]
+    })
+});
+
+assert.throws(function () {
+    FreakyValue({
+        outerArray: [
+            {
+                innerArray: [
+                    {
+                        value: "a"
+                    },
+                    {
+                        value: "b"
+                    }
+                ]
+            },
+            {
+                innerArray: [
+                    {
+                        value: 3
+                    },
+                    {
+                        value: "d"
+                    }
+                ]
+            }
         ]
     })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
-var stronglyTyped = require('../')
-var assert = require('assert')
+var stronglyTyped = require('../');
+var assert = require('assert');
+
+require("./arrayElementsValidation");
 
 var TypeA = stronglyTyped({
     "a": "string",


### PR DESCRIPTION
Motivation: I need validation of the arrays content user does provide. I would want array to verify it rather than map each element to strongly typed object.

It could allow multiple schemas (additional elements in array desc), but world where arrays contains unified values is a better world.